### PR TITLE
Initial Azure Gov backport.  Tested in Azure Commercial.

### DIFF
--- a/.github/workflows/apply_plan.yaml
+++ b/.github/workflows/apply_plan.yaml
@@ -31,8 +31,14 @@ jobs:
         with:
           path: infrastructure/terraform
           variables: |
-            subscription_id_hub               = "${{ env.ARM_SUBSCRIPTION_ID }}"
-            vm_admin_password                 = "${{ env.VM_PASSWORD }}"          
+            keyvault_admins_group_object_id       = "${{ secrets.AZURE_ADMINS_GROUP_OBJECT_ID }}" 
+            subscription_id_hub                   = "${{ env.ARM_SUBSCRIPTION_ID }}"
+            subscription_id_identity              = "${{ secrets.AZURE_IDENTITY_SUBSCRIPTION_ID }}" 
+            subscription_id_operations            = "${{ secrets.AZURE_OPERATIONS_SUBSCRIPTION_ID }}"
+            subscription_id_security              = "${{ secrets.AZURE_SECURITY_SUBSCRIPTION_ID }}" 
+            subscription_id_forensic              = "${{ secrets.AZURE_FORENSIC_SUBSCRIPTION_ID }}"
+            subscription_id_devsecops             = "${{ secrets.AZURE_DEVSECOPS_SUBSCRIPTION_ID }}"
+            vm_admin_password                     = "${{ env.VM_PASSWORD }}"           
           var_file: |
             infrastructure/terraform/tfvars/parameters.dev.tfvars
           backend_config: |

--- a/.github/workflows/check_for_drift.yaml
+++ b/.github/workflows/check_for_drift.yaml
@@ -27,8 +27,14 @@ jobs:
         with:
           path: infrastructure/terraform
           variables: |
-            subscription_id_hub               = "${{ env.ARM_SUBSCRIPTION_ID }}"
-            vm_admin_password                 = "${{ env.VM_PASSWORD }}"                    
+            keyvault_admins_group_object_id       = "${{ secrets.AZURE_ADMINS_GROUP_OBJECT_ID }}" 
+            subscription_id_hub                   = "${{ env.ARM_SUBSCRIPTION_ID }}"
+            subscription_id_identity              = "${{ secrets.AZURE_IDENTITY_SUBSCRIPTION_ID }}" 
+            subscription_id_operations            = "${{ secrets.AZURE_OPERATIONS_SUBSCRIPTION_ID }}"
+            subscription_id_security              = "${{ secrets.AZURE_SECURITY_SUBSCRIPTION_ID }}" 
+            subscription_id_forensic              = "${{ secrets.AZURE_FORENSIC_SUBSCRIPTION_ID }}"
+            subscription_id_devsecops             = "${{ secrets.AZURE_DEVSECOPS_SUBSCRIPTION_ID }}"
+            vm_admin_password                     = "${{ env.VM_PASSWORD }}"           
           var_file: |
             infrastructure/terraform/tfvars/parameters.dev.tfvars
           backend_config: |

--- a/.github/workflows/create_plan.yaml
+++ b/.github/workflows/create_plan.yaml
@@ -1,4 +1,4 @@
-name: Create Mission Enclave Management Landing Zone terraform plan
+name: Plan the Mission Enclave Management Landing Zone deployment
 
 on:
   workflow_dispatch:
@@ -30,7 +30,13 @@ jobs:
         with:
           path: infrastructure/terraform
           variables: |
+            keyvault_admins_group_object_id   = "${{ secrets.AZURE_ADMINS_GROUP_OBJECT_ID }}" 
             subscription_id_hub               = "${{ env.ARM_SUBSCRIPTION_ID }}"
+            subscription_id_identity          = "${{ secrets.AZURE_IDENTITY_SUBSCRIPTION_ID }}" 
+            subscription_id_operations        = "${{ secrets.AZURE_OPERATIONS_SUBSCRIPTION_ID }}"
+            subscription_id_security          = "${{ secrets.AZURE_SECURITY_SUBSCRIPTION_ID }}" 
+            subscription_id_forensic          = "${{ secrets.AZURE_FORENSIC_SUBSCRIPTION_ID }}"
+            subscription_id_devsecops         = "${{ secrets.AZURE_DEVSECOPS_SUBSCRIPTION_ID }}"
             vm_admin_password                 = "${{ env.VM_PASSWORD }}"           
           var_file: |
             infrastructure/terraform/tfvars/parameters.dev.tfvars

--- a/.github/workflows/destroy_plan.yaml
+++ b/.github/workflows/destroy_plan.yaml
@@ -28,10 +28,16 @@ jobs:
         with:
           path: infrastructure/terraform
           variables: |
+            keyvault_admins_group_object_id = "${{ secrets.AZURE_ADMINS_GROUP_OBJECT_ID }}" 
             subscription_id_hub               = "${{ env.ARM_SUBSCRIPTION_ID }}"
-            vm_admin_password                 = "${{ env.VM_PASSWORD }}"            
+            subscription_id_identity          = "${{ secrets.AZURE_IDENTITY_SUBSCRIPTION_ID }}" 
+            subscription_id_operations        = "${{ secrets.AZURE_OPERATIONS_SUBSCRIPTION_ID }}"
+            subscription_id_security          = "${{ secrets.AZURE_SECURITY_SUBSCRIPTION_ID }}" 
+            subscription_id_forensic          = "${{ secrets.AZURE_FORENSIC_SUBSCRIPTION_ID }}"
+            subscription_id_devsecops         = "${{ secrets.AZURE_DEVSECOPS_SUBSCRIPTION_ID }}"
+            vm_admin_password                 = "${{ env.VM_PASSWORD }}"           
           var_file: |
-            infrastructure/terraform/tfvars/parameters.dev.tfvars
+            infrastructure/terraform/tfvars/parameters.dev.gov.tfvars
           backend_config: |
             storage_account_name=${{ secrets.AZURE_TF_STATE_STORAGE_ACCOUNT_NAME }}
             container_name=${{ secrets.AZURE_TF_STATE_STORAGE_CONTAINER_NAME }}            

--- a/infrastructure/terraform/00-data.tf
+++ b/infrastructure/terraform/00-data.tf
@@ -21,17 +21,17 @@ module "mod_azregions_lookup" {
 module "az_regions" {
   count             = var.environment == "public" ? 1 : 0
   source          = "Azure/regions/azurerm"
-  version         = "0.6.0"
+  version         = "0.7.0"
   use_cached_data = false
 }
 
-# Get SKU for Commerical VMs
+/* # Get SKU for Commerical VMs
 module "get_valid_sku_for_deployment_region" {
   count             = var.environment == "public" ? 1 : 0
   source            = "./modules/vm_sku_selector"
   deployment_region = var.default_location
   environment       = var.environment
-}
+} */
 
 # Get current IP address for use in KV firewall rules
 data "http" "ip" {

--- a/infrastructure/terraform/00-locals.tf
+++ b/infrastructure/terraform/00-locals.tf
@@ -12,7 +12,7 @@ locals {
 # The following locals are used to define the service endpoints
 locals {
   fw_service_endpoints = var.environment == "public" ? [
-    "Microsoft.ActiveDirectory",
+    "Microsoft.AzureActiveDirectory",
     "Microsoft.AzureCosmosDB",
     "Microsoft.EventHub",
     "Microsoft.KeyVault",
@@ -85,6 +85,30 @@ locals {
       management_group_name      = "transport"
       parent_management_group_id = "platforms"
       subscription_ids           = ["${var.subscription_id_hub}"]
+    },
+    forensic = {
+      display_name               = "forensic"
+      management_group_name      = "forensic"
+      parent_management_group_id = "platforms"
+      subscription_ids           = ["${var.subscription_id_forensic}"]
+    },
+     identity = {
+      display_name               = "identity"
+      management_group_name      = "identity"
+      parent_management_group_id = "platforms"
+      subscription_ids           = ["${var.subscription_id_identity}"]
+    },
+     security = {
+      display_name               = "security"
+      management_group_name      = "security"
+      parent_management_group_id = "platforms"
+      subscription_ids           = ["${var.subscription_id_security}"]
+    },
+     devsecops = {
+      display_name               = "devsecops"
+      management_group_name      = "devsecops"
+      parent_management_group_id = "platforms"
+      subscription_ids           = ["${var.subscription_id_devsecops}"]
     },
     internal = {
       display_name               = "internal"

--- a/infrastructure/terraform/03b-modules.management.landing.zone.identity.tf
+++ b/infrastructure/terraform/03b-modules.management.landing.zone.identity.tf
@@ -66,7 +66,10 @@ module "mod_id_network" {
 
   # CIDRs for Azure Log Storage Account
   # This will allow the specified CIDRs to bypass the Azure Firewall for Azure Storage Account.
-  spoke_storage_bypass_ip_cidr = var.id_storage_bypass_ip_cidrs
+  spoke_storage_bypass_ip_cidr           = var.id_storage_bypass_ip_cidrs
+  spoke_storage_account_kind             = var.id_storage_account_kind
+  spoke_storage_account_replication_type = var.id_storage_account_replication_type
+  spoke_storage_account_tier             = var.id_storage_account_tier
 
   # (Optional) By default, this will apply resource locks to all resources created by this module.
   # To disable resource locks, set the argument to `enable_resource_locks = false`.

--- a/infrastructure/terraform/03c-modules.management.landing.zone.operations.tf
+++ b/infrastructure/terraform/03c-modules.management.landing.zone.operations.tf
@@ -69,7 +69,10 @@ module "mod_ops_network" {
 
   # CIDRs for Azure Log Storage Account
   # This will allow the specified CIDRs to bypass the Azure Firewall for Azure Storage Account.
-  spoke_storage_bypass_ip_cidr = var.ops_storage_bypass_ip_cidrs
+  spoke_storage_bypass_ip_cidr           = var.ops_storage_bypass_ip_cidrs
+  spoke_storage_account_kind             = var.ops_storage_account_kind
+  spoke_storage_account_tier             = var.ops_storage_account_tier
+  spoke_storage_account_replication_type = var.ops_storage_account_replication_type
 
   # (Optional) By default, this will apply resource locks to all resources created by this module.
   # To disable resource locks, set the argument to `enable_resource_locks = false`.
@@ -197,7 +200,7 @@ module "mod_ampls" {
   org_name                     = local.operations_short_name
 
   # Log Analytics Workspaces
-  linked_log_analytic_workspace_ids = [data.azurerm_log_analytics_workspace.log_analytics.id, data.azurerm_log_analytics_workspace.sec_log_analytics.id]
+  linked_log_analytic_workspace_ids = [data.azurerm_log_analytics_workspace.log_analytics.id, module.mod_security_logging.laws_resource_id] 
 
   # Private DNS details
   private_dns_zone_ids = [
@@ -212,7 +215,7 @@ module "mod_ampls" {
   # VNet and Subnet details
   # This need to be the same as the VNet and Subnet where the Private Endpoint will be deployed
   existing_ampls_virtual_network_id = data.azurerm_virtual_network.ops-vnet.id
-  existing_ampls_private_subnet_id  = data.azurerm_subnet.ops-ampls-snet.id # AMPLS Subnet index
+  existing_ampls_private_subnet_id  = module.mod_ops_network.subnet_ids["ampls"].id 
 
   # Depends on the Ops RG module
   depends_on = [module.mod_ops_scaffold_rg]

--- a/infrastructure/terraform/03d-modules.management.landing.zone.security.tf
+++ b/infrastructure/terraform/03d-modules.management.landing.zone.security.tf
@@ -69,7 +69,10 @@ module "mod_security_network" {
 
   # CIDRs for Azure Log Storage Account
   # This will allow the specified CIDRs to bypass the Azure Firewall for Azure Storage Account.
-  spoke_storage_bypass_ip_cidr = var.security_storage_bypass_ip_cidrs
+  spoke_storage_bypass_ip_cidr           = var.security_storage_bypass_ip_cidrs
+  spoke_storage_account_kind             = var.security_storage_account_kind
+  spoke_storage_account_tier             = var.security_storage_account_tier
+  spoke_storage_account_replication_type = var.security_storage_account_replication_type
 
   # (Optional) By default, this will apply resource locks to all resources created by this module.
   # To disable resource locks, set the argument to `enable_resource_locks = false`.

--- a/infrastructure/terraform/tfvars/parameters.dev.gov.tfvars
+++ b/infrastructure/terraform/tfvars/parameters.dev.gov.tfvars
@@ -282,6 +282,8 @@ enable_forced_tunneling_on_id_route_table = true
 
 # CIDRs for Identity Spkoke Azure Storage Account to bypass Azure Firewall
 id_storage_bypass_ip_cidrs = []
+# Need to uncomment the line below if deploying to a region where Zone Redundancy isn't available (Commercial or Gov).
+#id_storage_account_replication_type = "LRS"
 
 ####################################################
 # 03d Operations Management Spoke Virtual Network ###
@@ -326,6 +328,8 @@ enable_forced_tunneling_on_ops_route_table = true
 
 # CIDRs for Operations Spkoke Azure Storage Account to bypass Azure Firewall
 ops_storage_bypass_ip_cidrs = []
+# Need to uncomment the line below if deploying to a region where Zone Redundancy isn't available (Commercial or Gov).
+#ops_storage_account_replication_type = "LRS"
 
 ##########################################################
 # 03e DevSecOps Management Spoke Virtual Network       ###
@@ -362,6 +366,8 @@ enable_forced_tunneling_on_devsecops_route_table = true
 
 # CIDRs for DevSecOps Spkoke Azure Storage Account to bypass Azure Firewall
 devsecops_storage_bypass_ip_cidrs = []
+# Need to uncomment the line below if deploying to a region where Zone Redundancy isn't available (Commercial or Gov).
+#devsecops_storage_account_replication_type = "LRS"
 
 ####################################################
 # 03e Security Management Spoke Virtual Network  ###
@@ -399,6 +405,8 @@ enable_forced_tunneling_on_security_route_table = true
 
 # CIDRs for Security Spkoke Azure Storage Account to bypass Azure Firewall
 security_storage_bypass_ip_cidrs = []
+# Need to uncomment the line below if deploying to a region where Zone Redundancy isn't available (Commercial or Gov).
+#security_storage_account_replication_type = "LRS"
 
 #############################
 ## Peering Configuration  ###
@@ -429,7 +437,7 @@ keyvault_bypass_ip_cidrs = []
 win_source_image_reference = {
   publisher = "MicrosoftWindowsServer"
   offer     = "WindowsServer"
-  sku       = "2019-Datacenter"
+  sku       = "2022-datacenter-azure-edition"
   version   = "latest"
 }
 
@@ -438,7 +446,7 @@ win_source_image_reference = {
 /* linux_source_image_reference = {
   publisher = "Canonical"
   offer     = "UbuntuServe"
-  sku       = "18.04-LTS"
+  sku       = "22.04-LTS"
   version   = "latest"
 } */
 

--- a/infrastructure/terraform/tfvars/parameters.dev.tfvars
+++ b/infrastructure/terraform/tfvars/parameters.dev.tfvars
@@ -6,12 +6,12 @@
 ###########################
 
 # The prefixes to use for all resources in this deployment
-org_name           = "an3"    # This Prefix will be used on most deployed resources.  10 Characters max.
+org_name           = "an9"    # This Prefix will be used on most deployed resources.  10 Characters max.
 deploy_environment = "dev"    # dev | test | prod
 environment        = "public" # public | usgovernment
 
 # The default region to deploy to
-default_location = "eastus"
+default_location = "eastus2"
 
 # Enable locks on resources
 enable_resource_locks = false # true | false
@@ -422,7 +422,7 @@ keyvault_enabled_for_deployment          = true       # Enable deployment for th
 keyvault_enabled_for_disk_encryption     = true       # Enable disk encryption for the keyvault.
 keyvault_enabled_for_template_deployment = true       # Enable template deployment for the keyvault.
 
-# Bypass IP CIDRs for KeyVault
+# Bypass IP CIDRs for KeyVault firewall
 keyvault_bypass_ip_cidrs = []
 
 # Bastion Windows VM Configuration
@@ -432,12 +432,13 @@ win_source_image_reference = {
   sku       = "2019-Datacenter"
   version   = "latest"
 }
+vm_sku_size = "Standard_D2s_v3"
 
 # Bastion Linux VM Configuration
 # Uncomment the below lines to use a custom image for the linux bastion host
 /* linux_source_image_reference = {
   publisher = "Canonical"
-  offer     = "UbuntuServe"
+  offer     = "UbuntuServer"
   sku       = "18.04-LTS"
   version   = "latest"
 } */
@@ -462,7 +463,7 @@ action_group_short_name          = "anoaalerting"
 ##########################################
 
 enable_defender_for_cloud           = true # Enable Defender for Cloud
-security_center_contact_email       = "admin@contoso.com"
+security_center_contact_email       = "admin9@contoso.com"
 security_center_contact_phone       = "555-555-5555"
 security_center_alert_notifications = true
 security_center_alerts_to_admins    = true

--- a/infrastructure/terraform/variables.global.tf
+++ b/infrastructure/terraform/variables.global.tf
@@ -81,6 +81,13 @@ variable "subscription_id_security" {
   sensitive   = true
 }
 
+variable "subscription_id_forensic" {
+  type        = string
+  description = "If specified, identifies the Platform subscription for \"Forensicy\" for resource deployment and correct placement in the Management Group hierarchy."
+  default     = null
+  sensitive   = true
+}
+
 variable "subscription_id_devsecops" {
   type        = string
   description = "If specified, identifies the Platform subscription for \"DevSecOps\" for resource deployment and correct placement in the Management Group hierarchy."

--- a/infrastructure/terraform/variables.landing.zone.devsecops.tf
+++ b/infrastructure/terraform/variables.landing.zone.devsecops.tf
@@ -34,7 +34,25 @@ variable "enable_forced_tunneling_on_devsecops_route_table" {
 variable "devsecops_storage_bypass_ip_cidrs" {
   description = "The IP addresses to bypass for the devsecops storage account."
   type        = list(string)
-  default    = []  
+  default     = []
+}
+
+variable "devsecops_storage_account_kind" {
+  description = "The kind of the devsecops storage account."
+  type        = string
+  default     = "StorageV2"
+}
+
+variable "devsecops_storage_account_tier" {
+  description = "The tier of the devsecops storage account."
+  type        = string
+  default     = "Standard"
+}
+
+variable "devsecops_storage_account_replication_type" {
+  description = "The replication type of the devsecops storage account."
+  type        = string
+  default     = "ZRS"
 }
 
 ##########################
@@ -111,6 +129,12 @@ variable "keyvault_enabled_for_purge_protection" {
   description = "Enable purge protection for the keyvault."
   type        = bool
   default     = true
+}
+
+variable "keyvault_admins_group_object_id" {
+  description = "The object ID of the admins group that will be given access to the keyvault."
+  type        = string
+  sensitive   = true
 }
 
 ###############################

--- a/infrastructure/terraform/variables.landing.zone.identity.tf
+++ b/infrastructure/terraform/variables.landing.zone.identity.tf
@@ -42,3 +42,21 @@ variable "id_storage_bypass_ip_cidrs" {
   type        = list(string)
   default    = []  
 }
+
+variable "id_storage_account_kind" {
+  description = "The kind of the id storage account."
+  type        = string
+  default     = "StorageV2"
+}
+
+variable "id_storage_account_tier" {
+  description = "The tier of the id storage account."
+  type        = string
+  default     = "Standard"
+}
+
+variable "id_storage_account_replication_type" {
+  description = "The replication type of the id storage account."
+  type        = string
+  default     = "ZRS"
+}

--- a/infrastructure/terraform/variables.landing.zone.operations.tf
+++ b/infrastructure/terraform/variables.landing.zone.operations.tf
@@ -36,3 +36,21 @@ variable "ops_storage_bypass_ip_cidrs" {
   type        = list(string)
   default    = []  
 }
+
+variable "ops_storage_account_kind" {
+  description = "The kind of the operations storage account."
+  type        = string
+  default     = "StorageV2"
+}
+
+variable "ops_storage_account_tier" {
+  description = "The tier of the operations storage account."
+  type        = string
+  default     = "Standard"
+}
+
+variable "ops_storage_account_replication_type" {
+  description = "The replication of the operations storage account."
+  type        = string
+  default     = "ZRS"
+}

--- a/infrastructure/terraform/variables.landing.zone.security.tf
+++ b/infrastructure/terraform/variables.landing.zone.security.tf
@@ -42,3 +42,21 @@ variable "security_storage_bypass_ip_cidrs" {
   type        = list(string)
   default    = []  
 }
+
+variable "security_storage_account_kind" {
+  description = "The kind of the security storage account."
+  type        = string
+  default     = "StorageV2"
+}
+
+variable "security_storage_account_tier" {
+  description = "The tier of the security storage account."
+  type        = string
+  default     = "Standard"
+}
+
+variable "security_storage_account_replication_type" {
+  description = "The replication type of the security storage account."
+  type        = string
+  default     = "ZRS"
+}

--- a/infrastructure/terraform/versions.tf
+++ b/infrastructure/terraform/versions.tf
@@ -122,6 +122,25 @@ provider "azurerm" {
 }
 
 provider "azurerm" {
+  alias           = "forensic"
+  subscription_id = coalesce(var.subscription_id_forensic, var.subscription_id_hub)
+  environment     = var.environment
+  skip_provider_registration = var.environment == "usgovernment" ? true : false
+  features {
+    log_analytics_workspace {
+      permanently_delete_on_destroy = var.provider_azurerm_features_keyvault.permanently_delete_on_destroy
+    }
+    key_vault {
+      purge_soft_delete_on_destroy = var.provider_azurerm_features_keyvault.purge_soft_delete_on_destroy
+    }
+    resource_group {
+      prevent_deletion_if_contains_resources = var.provider_azurerm_features_resource_group.prevent_deletion_if_contains_resources # When that feature flag is set to true, this is required to stop the deletion of the resource group when the deployment is destroyed. This is required if the resource group contains resources that are not managed by Terraform.
+    }
+  }
+  storage_use_azuread = true
+}
+
+provider "azurerm" {
   alias           = "devsecops"
   subscription_id = coalesce(var.subscription_id_devsecops, var.subscription_id_hub)
   environment     = var.environment


### PR DESCRIPTION
# Description
1. Updated GitHub Actions to support full range of Subscription IDs
2. Updated `az_regions` version and disabled `get_valid_skus_for_deployment_region` because it was returning Null when the region had capacity issues and the internal Microsoft subscriptions had their VM quota removed.
3. Update Service Endpoints list to support Commercial and Gov clouds.
4. Expanded Management Groups hierarchy to match documentation
5. Expanded Spoke Storage Account variables to support overrides for Azure Gov. 
6. Removed data call references to lower the risk that the `terraform plan` could not figure out a piece of information (like resource name or location) at `plan` time so it decides to destroy and rebuild resources that shouldn't be touched.
7. Added keyvault permissions for a user-specified `admin` group.

# Type of Change

```bash
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
```

# Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

```bash
- [ ] The documentation is updated to cover any new or changed features
- [x] Manual tests have passed
```
